### PR TITLE
Fix types for languages.yaml namespaces

### DIFF
--- a/src/monaco.d.ts
+++ b/src/monaco.d.ts
@@ -2,53 +2,56 @@
  *  Copyright (c) Microsoft Corporation. All rights reserved.
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
+import { IEvent } from 'monaco-editor';
 
-declare namespace monaco.languages.yaml {
-  export interface DiagnosticsOptions {
-    /**
-     * If set, the validator will be enabled and perform syntax validation as well as schema based validation.
-     */
-    readonly validate?: boolean;
-
-    /**
-     * A list of known schemas and/or associations of schemas to file names.
-     */
-    readonly schemas?: Array<{
+declare module 'monaco-editor' {
+  namespace languages.yaml {
+    export interface DiagnosticsOptions {
       /**
-       * The URI of the schema, which is also the identifier of the schema.
+       * If set, the validator will be enabled and perform syntax validation as well as schema based validation.
        */
-      readonly uri: string;
-      /**
-       * A list of file names that are associated to the schema. The '*' wildcard can be used. For example '*.schema.json', 'package.json'
-       */
-      readonly fileMatch?: string[];
-      /**
-       * The schema for the given URI.
-       */
-      readonly schema?: any;
-    }>;
+      readonly validate?: boolean;
 
-    /**
-     *  If set, the schema service would load schema content on-demand with 'fetch' if available
-     */
-    readonly enableSchemaRequest?: boolean;
-    /**
-     * If specified, this prefix will be added to all on demand schema requests
-     */
-    readonly prefix?: string;
-    /**
-     * Whether or not kubernetes yaml is supported
-     */
-    readonly isKubernetes?: boolean;
+      /**
+       * A list of known schemas and/or associations of schemas to file names.
+       */
+      readonly schemas?: Array<{
+        /**
+         * The URI of the schema, which is also the identifier of the schema.
+         */
+        readonly uri: string;
+        /**
+         * A list of file names that are associated to the schema. The '*' wildcard can be used. For example '*.schema.json', 'package.json'
+         */
+        readonly fileMatch?: string[];
+        /**
+         * The schema for the given URI.
+         */
+        readonly schema?: any;
+      }>;
 
-    readonly format?: boolean;
+      /**
+       *  If set, the schema service would load schema content on-demand with 'fetch' if available
+       */
+      readonly enableSchemaRequest?: boolean;
+      /**
+       * If specified, this prefix will be added to all on demand schema requests
+       */
+      readonly prefix?: string;
+      /**
+       * Whether or not kubernetes yaml is supported
+       */
+      readonly isKubernetes?: boolean;
+
+      readonly format?: boolean;
+    }
+
+    export interface LanguageServiceDefaults {
+      readonly onDidChange: IEvent<LanguageServiceDefaults>;
+      readonly diagnosticsOptions: DiagnosticsOptions;
+      setDiagnosticsOptions(options: DiagnosticsOptions): void;
+    }
+
+    export const yamlDefaults: LanguageServiceDefaults;
   }
-
-  export interface LanguageServiceDefaults {
-    readonly onDidChange: IEvent<LanguageServiceDefaults>;
-    readonly diagnosticsOptions: DiagnosticsOptions;
-    setDiagnosticsOptions(options: DiagnosticsOptions): void;
-  }
-
-  export const yamlDefaults: LanguageServiceDefaults;
 }


### PR DESCRIPTION
`monaco-editor` no longer uses a global `monaco` namespace.

This may resolve #37

A workaround can be seen [here](https://gitlab.com/appsemble/appsemble/-/blob/4a7b78cbfcb4366f5209327ff00a1ee5986b389e/packages/studio/src/components/MonacoEditor/custom.ts#L5-17).

I was able to remove this workaround after applying the changes in this PR locally in `node_modules/monaco-yaml/lib/monaco.d.ts`