### PR TITLE
Replace monaco namespace with monaco-editor imports

### DIFF
--- a/examples/react-webpack-worker-loader/package.json
+++ b/examples/react-webpack-worker-loader/package.json
@@ -17,7 +17,7 @@
     "css-loader": "^3.4.2",
     "file-loader": "^5.1.0",
     "html-webpack-plugin": "^3.2.0",
-    "monaco-editor": "^0.20.0",
+    "monaco-editor": "^0.21.3",
     "monaco-yaml": "file:../..",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",

--- a/examples/react-webpack-worker-loader/yarn.lock
+++ b/examples/react-webpack-worker-loader/yarn.lock
@@ -1037,6 +1037,11 @@ aproba@^1.1.1:
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
   integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
 
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+
 arr-diff@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/arr-diff/-/arr-diff-4.0.0.tgz#d6461074febfec71e7e15235761a329a5dc7c520"
@@ -3066,6 +3071,13 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
+js-yaml@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.0.0.tgz#f426bc0ff4b4051926cd588c71113183409a121f"
+  integrity sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==
+  dependencies:
+    argparse "^2.0.1"
+
 jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
@@ -3421,17 +3433,16 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
-monaco-editor@^0.20.0:
-  version "0.20.0"
-  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.20.0.tgz#5d5009343a550124426cb4d965a4d27a348b4dea"
-  integrity sha512-hkvf4EtPJRMQlPC3UbMoRs0vTAFAYdzFQ+gpMb8A+9znae1c43q8Mab9iVsgTcg/4PNiLGGn3SlDIa8uvK1FIQ==
+monaco-editor@^0.21.3:
+  version "0.21.3"
+  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.21.3.tgz#3381b66614b64d1c5e3b77dd5564ad496d1b4e5d"
+  integrity sha512-9N7wATLpi+googstvtm6IKg97vPQ77FDYEpkow5tLriM/VJ0DaTRyUP4UVzcoH7KlPDX+e/rE7/imcOUeGkT6g==
 
-monaco-yaml@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/monaco-yaml/-/monaco-yaml-2.4.0.tgz#027307a231d809c416babf1cf89b4c1bb940e55d"
-  integrity sha512-ElUS6uBqEjA2/o2gLuNdnqWSAAQXh8ISr1kwlFErm3t5IXO74TNfS3gnjO6Kv9TXS7LImjGfgPAZei7o8zNTHw==
-  optionalDependencies:
-    prettier "^1.19.1"
+"monaco-yaml@file:../..":
+  version "2.5.0"
+  dependencies:
+    js-yaml "^4.0.0"
+    yaml-ast-parser-custom-tags "^0.0.43"
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -3945,11 +3956,6 @@ postcss@^7.0.14, postcss@^7.0.16, postcss@^7.0.23, postcss@^7.0.5, postcss@^7.0.
     chalk "^2.4.2"
     source-map "^0.6.1"
     supports-color "^6.1.0"
-
-prettier@^1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 pretty-error@^2.0.2:
   version "2.1.1"
@@ -5301,6 +5307,11 @@ yallist@^3.0.2:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
+
+yaml-ast-parser-custom-tags@^0.0.43:
+  version "0.0.43"
+  resolved "https://registry.yarnpkg.com/yaml-ast-parser-custom-tags/-/yaml-ast-parser-custom-tags-0.0.43.tgz#46968145ce4e24cb03c3312057f0f141b93a7d02"
+  integrity sha512-R5063FF/JSAN6qXCmylwjt9PcDH6M0ExEme/nJBzLspc6FJDmHHIqM7xh2WfEmsTJqClF79A9VkXjkAqmZw9SQ==
 
 yargs-parser@^11.1.1:
   version "11.1.1"

--- a/examples/react-webpack-worker-loader/yarn.lock
+++ b/examples/react-webpack-worker-loader/yarn.lock
@@ -1037,10 +1037,12 @@ aproba@^1.1.1:
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
   integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
 
-argparse@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
-  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+argparse@^1.0.7:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
+  integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
+  dependencies:
+    sprintf-js "~1.0.2"
 
 arr-diff@^4.0.0:
   version "4.0.0"
@@ -2119,6 +2121,11 @@ eslint-scope@^4.0.3:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+esprima@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
+  integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
+
 esrecurse@^4.1.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.1.tgz#007a3b9fdbc2b3bb87e4879ea19c92fdbd3942cf"
@@ -3071,12 +3078,13 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.0.0.tgz#f426bc0ff4b4051926cd588c71113183409a121f"
-  integrity sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==
+js-yaml@^3.14.1:
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
+  integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
   dependencies:
-    argparse "^2.0.1"
+    argparse "^1.0.7"
+    esprima "^4.0.0"
 
 jsesc@^2.5.1:
   version "2.5.2"
@@ -3441,7 +3449,7 @@ monaco-editor@^0.21.3:
 "monaco-yaml@file:../..":
   version "2.5.0"
   dependencies:
-    js-yaml "^4.0.0"
+    js-yaml "^3.14.1"
     yaml-ast-parser-custom-tags "^0.0.43"
 
 move-concurrently@^1.0.1:
@@ -4648,6 +4656,11 @@ split-string@^3.0.1, split-string@^3.0.2:
   integrity sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==
   dependencies:
     extend-shallow "^3.0.0"
+
+sprintf-js@~1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+  integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
 ssri@^6.0.1:
   version "6.0.1"

--- a/examples/react-webpack/package.json
+++ b/examples/react-webpack/package.json
@@ -17,7 +17,7 @@
     "css-loader": "^3.4.2",
     "file-loader": "^5.1.0",
     "html-webpack-plugin": "^3.2.0",
-    "monaco-editor": "^0.20.0",
+    "monaco-editor": "^0.21.3",
     "monaco-yaml": "file:../..",
     "react": "^16.12.0",
     "react-dom": "^16.12.0",

--- a/examples/react-webpack/yarn.lock
+++ b/examples/react-webpack/yarn.lock
@@ -1037,10 +1037,12 @@ aproba@^1.1.1:
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
   integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
 
-argparse@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
-  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
+argparse@^1.0.7:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
+  integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
+  dependencies:
+    sprintf-js "~1.0.2"
 
 arr-diff@^4.0.0:
   version "4.0.0"
@@ -2119,6 +2121,11 @@ eslint-scope@^4.0.3:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+esprima@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
+  integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
+
 esrecurse@^4.1.0:
   version "4.2.1"
   resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.1.tgz#007a3b9fdbc2b3bb87e4879ea19c92fdbd3942cf"
@@ -3071,12 +3078,13 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.0.0.tgz#f426bc0ff4b4051926cd588c71113183409a121f"
-  integrity sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==
+js-yaml@^3.14.1:
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
+  integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
   dependencies:
-    argparse "^2.0.1"
+    argparse "^1.0.7"
+    esprima "^4.0.0"
 
 jsesc@^2.5.1:
   version "2.5.2"
@@ -3433,7 +3441,7 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
-monaco-editor@0.21.3, monaco-editor@^0.21.3:
+monaco-editor@^0.21.3:
   version "0.21.3"
   resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.21.3.tgz#3381b66614b64d1c5e3b77dd5564ad496d1b4e5d"
   integrity sha512-9N7wATLpi+googstvtm6IKg97vPQ77FDYEpkow5tLriM/VJ0DaTRyUP4UVzcoH7KlPDX+e/rE7/imcOUeGkT6g==
@@ -3441,7 +3449,7 @@ monaco-editor@0.21.3, monaco-editor@^0.21.3:
 "monaco-yaml@file:../..":
   version "2.5.0"
   dependencies:
-    js-yaml "^4.0.0"
+    js-yaml "^3.14.1"
     yaml-ast-parser-custom-tags "^0.0.43"
 
 move-concurrently@^1.0.1:
@@ -4640,6 +4648,11 @@ split-string@^3.0.1, split-string@^3.0.2:
   integrity sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==
   dependencies:
     extend-shallow "^3.0.0"
+
+sprintf-js@~1.0.2:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
+  integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
 ssri@^6.0.1:
   version "6.0.1"

--- a/examples/react-webpack/yarn.lock
+++ b/examples/react-webpack/yarn.lock
@@ -972,13 +972,6 @@ acorn@^6.2.1:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.0.tgz#b659d2ffbafa24baf5db1cdbb2c94a983ecd2784"
   integrity sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==
 
-agent-base@4, agent-base@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-4.3.0.tgz#8165f01c436009bccad0b1d122f05ed770efc6ee"
-  integrity sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==
-  dependencies:
-    es6-promisify "^5.0.0"
-
 ajv-errors@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/ajv-errors/-/ajv-errors-1.0.1.tgz#f35986aceb91afadec4102fbd85014950cefa64d"
@@ -1044,12 +1037,10 @@ aproba@^1.1.1:
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
   integrity sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
 
-argparse@^1.0.7:
-  version "1.0.10"
-  resolved "https://registry.yarnpkg.com/argparse/-/argparse-1.0.10.tgz#bcd6791ea5ae09725e17e5ad988134cd40b3d911"
-  integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
-  dependencies:
-    sprintf-js "~1.0.2"
+argparse@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
+  integrity sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==
 
 arr-diff@^4.0.0:
   version "4.0.0"
@@ -1793,14 +1784,7 @@ debug@2.6.9, debug@^2.2.0, debug@^2.3.3:
   dependencies:
     ms "2.0.0"
 
-debug@3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
-  integrity sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==
-  dependencies:
-    ms "2.0.0"
-
-debug@^3.0.0, debug@^3.1.0, debug@^3.1.1, debug@^3.2.5:
+debug@^3.0.0, debug@^3.1.1, debug@^3.2.5:
   version "3.2.6"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.2.6.tgz#e83d17de16d8a7efb7717edbe5fb10135eee629b"
   integrity sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==
@@ -2117,18 +2101,6 @@ es-to-primitive@^1.2.1:
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
 
-es6-promise@^4.0.3:
-  version "4.2.8"
-  resolved "https://registry.yarnpkg.com/es6-promise/-/es6-promise-4.2.8.tgz#4eb21594c972bc40553d276e510539143db53e0a"
-  integrity sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==
-
-es6-promisify@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/es6-promisify/-/es6-promisify-5.0.0.tgz#5109d62f3e56ea967c4b63505aef08291c8a5203"
-  integrity sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=
-  dependencies:
-    es6-promise "^4.0.3"
-
 escape-html@~1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
@@ -2146,11 +2118,6 @@ eslint-scope@^4.0.3:
   dependencies:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
-
-esprima@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/esprima/-/esprima-4.0.1.tgz#13b04cdb3e6c5d19df91ab6987a8695619b0aa71"
-  integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
 esrecurse@^4.1.0:
   version "4.2.1"
@@ -2750,14 +2717,6 @@ http-errors@~1.7.2:
   resolved "https://registry.yarnpkg.com/http-parser-js/-/http-parser-js-0.4.10.tgz#92c9c1374c35085f75db359ec56cc257cbb93fa4"
   integrity sha1-ksnBN0w1CF912zWexWzCV8u5P6Q=
 
-http-proxy-agent@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/http-proxy-agent/-/http-proxy-agent-2.1.0.tgz#e4821beef5b2142a2026bd73926fe537631c5405"
-  integrity sha512-qwHbBLV7WviBl0rQsOzH6o5lwyOIvwp/BdFnvVxXORldu5TmjFfjzBcWUWS5kWAZhmv+JtiDhSuQCp4sBfbIgg==
-  dependencies:
-    agent-base "4"
-    debug "3.1.0"
-
 http-proxy-middleware@0.19.1:
   version "0.19.1"
   resolved "https://registry.yarnpkg.com/http-proxy-middleware/-/http-proxy-middleware-0.19.1.tgz#183c7dc4aa1479150306498c210cdaf96080a43a"
@@ -2781,14 +2740,6 @@ https-browserify@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/https-browserify/-/https-browserify-1.0.0.tgz#ec06c10e0a34c0f2faf199f7fd7fc78fffd03c73"
   integrity sha1-7AbBDgo0wPL68Zn3/X/Hj//QPHM=
-
-https-proxy-agent@^2.2.3:
-  version "2.2.4"
-  resolved "https://registry.yarnpkg.com/https-proxy-agent/-/https-proxy-agent-2.2.4.tgz#4ee7a737abd92678a293d9b34a1af4d0d08c787b"
-  integrity sha512-OmvfoQ53WLjtA9HeYP9RNrWMJzzAz1JGaSFr1nijg0PVR1JaD/xbJq1mdEIIlxGpXp9eSe/O2LgU9DJmTPd0Eg==
-  dependencies:
-    agent-base "^4.3.0"
-    debug "^3.1.0"
 
 iconv-lite@0.4.24:
   version "0.4.24"
@@ -3120,13 +3071,12 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@^3.13.1:
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.0.tgz#a7a34170f26a21bb162424d8adacb4113a69e482"
-  integrity sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==
+js-yaml@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-4.0.0.tgz#f426bc0ff4b4051926cd588c71113183409a121f"
+  integrity sha512-pqon0s+4ScYUvX30wxQi3PogGFAlUyH0awepWvwkj4jD4v+ova3RiYw8bmA6x2rDrEaj8i/oWKoRxpVNW+Re8Q==
   dependencies:
-    argparse "^1.0.7"
-    esprima "^4.0.0"
+    argparse "^2.0.1"
 
 jsesc@^2.5.1:
   version "2.5.2"
@@ -3171,11 +3121,6 @@ json5@^2.1.0:
   integrity sha512-l+3HXD0GEI3huGq1njuqtzYK8OYJyXMkOLtQ53pjWh89tvWS2h6l+1zMkYWqlb57+SiQodKZyvMEFb2X+KrFhQ==
   dependencies:
     minimist "^1.2.0"
-
-jsonc-parser@^2.2.1:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/jsonc-parser/-/jsonc-parser-2.3.0.tgz#7c7fc988ee1486d35734faaaa866fadb00fa91ee"
-  integrity sha512-b0EBt8SWFNnixVdvoR2ZtEGa9ZqLhbJnOjezn+WP+8kspFm+PFYDN8Z4Bc7pRlDjvuVcADSUkroIuTWWn/YiIA==
 
 killable@^1.0.1:
   version "1.0.1"
@@ -3488,17 +3433,16 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "0.0.8"
 
-monaco-editor@^0.20.0:
-  version "0.20.0"
-  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.20.0.tgz#5d5009343a550124426cb4d965a4d27a348b4dea"
-  integrity sha512-hkvf4EtPJRMQlPC3UbMoRs0vTAFAYdzFQ+gpMb8A+9znae1c43q8Mab9iVsgTcg/4PNiLGGn3SlDIa8uvK1FIQ==
+monaco-editor@0.21.3, monaco-editor@^0.21.3:
+  version "0.21.3"
+  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.21.3.tgz#3381b66614b64d1c5e3b77dd5564ad496d1b4e5d"
+  integrity sha512-9N7wATLpi+googstvtm6IKg97vPQ77FDYEpkow5tLriM/VJ0DaTRyUP4UVzcoH7KlPDX+e/rE7/imcOUeGkT6g==
 
 "monaco-yaml@file:../..":
-  version "2.4.1"
+  version "2.5.0"
   dependencies:
-    yaml-language-server "^0.9.0"
-  optionalDependencies:
-    prettier "^1.19.1"
+    js-yaml "^4.0.0"
+    yaml-ast-parser-custom-tags "^0.0.43"
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -4013,11 +3957,6 @@ postcss@^7.0.14, postcss@^7.0.16, postcss@^7.0.23, postcss@^7.0.5, postcss@^7.0.
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-prettier@^1.18.2, prettier@^1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
-  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
-
 pretty-error@^2.0.2:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/pretty-error/-/pretty-error-2.1.1.tgz#5f4f87c8f91e5ae3f3ba87ab4cf5e03b1a17f1a3"
@@ -4322,15 +4261,6 @@ repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
-
-request-light@^0.2.4:
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/request-light/-/request-light-0.2.5.tgz#38a3da7b2e56f7af8cbba57e8a94930ee2380746"
-  integrity sha512-eBEh+GzJAftUnex6tcL6eV2JCifY0+sZMIUpUPOVXbs2nV5hla4ZMmO3icYKGuGVuQ2zHE9evh4OrRcH4iyYYw==
-  dependencies:
-    http-proxy-agent "^2.1.0"
-    https-proxy-agent "^2.2.3"
-    vscode-nls "^4.1.1"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -4710,11 +4640,6 @@ split-string@^3.0.1, split-string@^3.0.2:
   integrity sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==
   dependencies:
     extend-shallow "^3.0.0"
-
-sprintf-js@~1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
-  integrity sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
 
 ssri@^6.0.1:
   version "6.0.1"
@@ -5162,68 +5087,6 @@ vm-browserify@^1.0.1:
   resolved "https://registry.yarnpkg.com/vm-browserify/-/vm-browserify-1.1.2.tgz#78641c488b8e6ca91a75f511e7a3b32a86e5dda0"
   integrity sha512-2ham8XPWTONajOR0ohOKOHXkm3+gaBmGut3SRuu75xLd/RRaY6vqgh8NBYYk7+RW3u5AtzPQZG8F10LHkl0lAQ==
 
-vscode-json-languageservice@^3.6.0:
-  version "3.7.0"
-  resolved "https://registry.yarnpkg.com/vscode-json-languageservice/-/vscode-json-languageservice-3.7.0.tgz#0174417f139cf41dd60c84538fd052385bfb46f6"
-  integrity sha512-nGLqcBhTjdfkl8Dz9sYGK/ZCTjscYFoIjYw+qqkWB+vyNfM0k/AyIoT73DQvB/PArteCKjEVfQUF72GRZEDSbQ==
-  dependencies:
-    jsonc-parser "^2.2.1"
-    vscode-languageserver-textdocument "^1.0.1"
-    vscode-languageserver-types "^3.15.1"
-    vscode-nls "^4.1.2"
-    vscode-uri "^2.1.2"
-
-vscode-jsonrpc@^4.0.0:
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/vscode-jsonrpc/-/vscode-jsonrpc-4.0.0.tgz#a7bf74ef3254d0a0c272fab15c82128e378b3be9"
-  integrity sha512-perEnXQdQOJMTDFNv+UF3h1Y0z4iSiaN9jIlb0OqIYgosPCZGYh/MCUlkFtV2668PL69lRDO32hmvL2yiidUYg==
-
-vscode-languageserver-protocol@3.14.1:
-  version "3.14.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.14.1.tgz#b8aab6afae2849c84a8983d39a1cf742417afe2f"
-  integrity sha512-IL66BLb2g20uIKog5Y2dQ0IiigW0XKrvmWiOvc0yXw80z3tMEzEnHjaGAb3ENuU7MnQqgnYJ1Cl2l9RvNgDi4g==
-  dependencies:
-    vscode-jsonrpc "^4.0.0"
-    vscode-languageserver-types "3.14.0"
-
-vscode-languageserver-textdocument@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.1.tgz#178168e87efad6171b372add1dea34f53e5d330f"
-  integrity sha512-UIcJDjX7IFkck7cSkNNyzIz5FyvpQfY7sdzVy+wkKN/BLaD4DQ0ppXQrKePomCxTS7RrolK1I0pey0bG9eh8dA==
-
-vscode-languageserver-types@3.14.0:
-  version "3.14.0"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.14.0.tgz#d3b5952246d30e5241592b6dde8280e03942e743"
-  integrity sha512-lTmS6AlAlMHOvPQemVwo3CezxBp0sNB95KNPkqp3Nxd5VFEnuG1ByM0zlRWos0zjO3ZWtkvhal0COgiV1xIA4A==
-
-vscode-languageserver-types@^3.15.1:
-  version "3.15.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver-types/-/vscode-languageserver-types-3.15.1.tgz#17be71d78d2f6236d414f0001ce1ef4d23e6b6de"
-  integrity sha512-+a9MPUQrNGRrGU630OGbYVQ+11iOIovjCkqxajPa9w57Sd5ruK8WQNsslzpa0x/QJqC8kRc2DUxWjIFwoNm4ZQ==
-
-vscode-languageserver@^5.2.1:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/vscode-languageserver/-/vscode-languageserver-5.2.1.tgz#0d2feddd33f92aadf5da32450df498d52f6f14eb"
-  integrity sha512-GuayqdKZqAwwaCUjDvMTAVRPJOp/SLON3mJ07eGsx/Iq9HjRymhKWztX41rISqDKhHVVyFM+IywICyZDla6U3A==
-  dependencies:
-    vscode-languageserver-protocol "3.14.1"
-    vscode-uri "^1.0.6"
-
-vscode-nls@^4.1.1, vscode-nls@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/vscode-nls/-/vscode-nls-4.1.2.tgz#ca8bf8bb82a0987b32801f9fddfdd2fb9fd3c167"
-  integrity sha512-7bOHxPsfyuCqmP+hZXscLhiHwe7CSuFE4hyhbs22xPIhQ4jv99FcR4eBzfYYVLP356HNFpdvz63FFb/xw6T4Iw==
-
-vscode-uri@^1.0.6:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-1.0.8.tgz#9769aaececae4026fb6e22359cb38946580ded59"
-  integrity sha512-obtSWTlbJ+a+TFRYGaUumtVwb+InIUVI0Lu0VBUAPmj2cU5JutEXg3xUE0c2J5Tcy7h2DEKVJBFi+Y9ZSFzzPQ==
-
-vscode-uri@^2.1.1, vscode-uri@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/vscode-uri/-/vscode-uri-2.1.2.tgz#c8d40de93eb57af31f3c715dd650e2ca2c096f1c"
-  integrity sha512-8TEXQxlldWAuIODdukIb+TR5s+9Ds40eSJrw+1iDDA9IFORPjMELarNQE3myz5XIkWWpdprmJjm1/SxMlWOC8A==
-
 watchpack@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/watchpack/-/watchpack-1.6.0.tgz#4bc12c2ebe8aa277a71f1d3f14d685c7b446cd00"
@@ -5429,27 +5292,10 @@ yallist@^3.0.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
-yaml-ast-parser-custom-tags@0.0.43:
+yaml-ast-parser-custom-tags@^0.0.43:
   version "0.0.43"
   resolved "https://registry.yarnpkg.com/yaml-ast-parser-custom-tags/-/yaml-ast-parser-custom-tags-0.0.43.tgz#46968145ce4e24cb03c3312057f0f141b93a7d02"
   integrity sha512-R5063FF/JSAN6qXCmylwjt9PcDH6M0ExEme/nJBzLspc6FJDmHHIqM7xh2WfEmsTJqClF79A9VkXjkAqmZw9SQ==
-
-yaml-language-server@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/yaml-language-server/-/yaml-language-server-0.9.0.tgz#6f7b0068dfd182589320da7d36f7ade897f6c4a0"
-  integrity sha512-nRExM5NfJXzxTKlFmHKr/ZtoxZCddH1kuuWNfHRvTLCEHzexIn/YvI/DBZHxKLh/ym9f4Q4j4zW76vB6J18lUQ==
-  dependencies:
-    js-yaml "^3.13.1"
-    jsonc-parser "^2.2.1"
-    request-light "^0.2.4"
-    vscode-json-languageservice "^3.6.0"
-    vscode-languageserver "^5.2.1"
-    vscode-languageserver-types "^3.15.1"
-    vscode-nls "^4.1.2"
-    vscode-uri "^2.1.1"
-    yaml-ast-parser-custom-tags "0.0.43"
-  optionalDependencies:
-    prettier "^1.18.2"
 
 yargs-parser@^11.1.1:
   version "11.1.1"

--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
   "devDependencies": {
     "husky": "^5.2.0",
     "lint-staged": "^10.5.4",
-    "monaco-editor": "^0.21.2",
-    "monaco-editor-core": "^0.21.2",
+    "monaco-editor": "^0.21.3",
     "monaco-languages": "^2.1.1",
     "monaco-plugin-helpers": "^1.0.3",
     "prettier": "2.0.5",

--- a/scripts/bundle-umd.js
+++ b/scripts/bundle-umd.js
@@ -33,7 +33,8 @@ function bundleOne(moduleId, exclude) {
       exclude: exclude,
       paths: {
         'vs/language/yaml': REPO_ROOT + '/out/amd',
-        'monaco-editor': REPO_ROOT + '/out/amd/fillers/monaco-editor-amd',
+        'monaco-editor/esm/vs/editor/editor.api':
+          REPO_ROOT + '/out/amd/fillers/monaco-editor-amd',
       },
       optimize: 'none',
       packages: [

--- a/scripts/bundle-umd.js
+++ b/scripts/bundle-umd.js
@@ -33,6 +33,7 @@ function bundleOne(moduleId, exclude) {
       exclude: exclude,
       paths: {
         'vs/language/yaml': REPO_ROOT + '/out/amd',
+        'monaco-editor': REPO_ROOT + '/out/amd/fillers/monaco-editor-amd',
       },
       optimize: 'none',
       packages: [

--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -13,12 +13,11 @@ import Uri = monaco.Uri;
 import Position = monaco.Position;
 import Range = monaco.Range;
 import IRange = monaco.IRange;
-import Thenable = monaco.Thenable;
 import CancellationToken = monaco.CancellationToken;
 import IDisposable = monaco.IDisposable;
 import { CustomFormatterOptions } from 'yaml-language-server';
 
-export type WorkerAccessor = (...more: Uri[]) => Thenable<YAMLWorker>;
+export type WorkerAccessor = (...more: Uri[]) => PromiseLike<YAMLWorker>;
 
 // --- diagnostics --- ---
 
@@ -304,7 +303,7 @@ export class CompletionAdapter
     position: Position,
     context: monaco.languages.CompletionContext,
     token: CancellationToken
-  ): Thenable<monaco.languages.CompletionList> {
+  ): PromiseLike<monaco.languages.CompletionList> {
     const resource = model.uri;
 
     return this._worker(resource)
@@ -412,7 +411,7 @@ export class HoverAdapter implements monaco.languages.HoverProvider {
     model: monaco.editor.IReadOnlyModel,
     position: Position,
     token: CancellationToken
-  ): Thenable<monaco.languages.Hover> {
+  ): PromiseLike<monaco.languages.Hover> {
     const resource = model.uri;
 
     return this._worker(resource)
@@ -484,7 +483,7 @@ export class DocumentSymbolAdapter
   public provideDocumentSymbols(
     model: monaco.editor.IReadOnlyModel,
     token: CancellationToken
-  ): Thenable<monaco.languages.DocumentSymbol[]> {
+  ): PromiseLike<monaco.languages.DocumentSymbol[]> {
     const resource = model.uri;
 
     return this._worker(resource)
@@ -530,7 +529,7 @@ export class DocumentFormattingEditProvider
     model: monaco.editor.IReadOnlyModel,
     options: monaco.languages.FormattingOptions,
     token: CancellationToken
-  ): Thenable<monaco.editor.ISingleEditOperation[]> {
+  ): PromiseLike<monaco.editor.ISingleEditOperation[]> {
     const resource = model.uri;
 
     return this._worker(resource).then((worker) => {
@@ -555,7 +554,7 @@ export class DocumentRangeFormattingEditProvider
     range: Range,
     options: monaco.languages.FormattingOptions,
     token: CancellationToken
-  ): Thenable<monaco.editor.ISingleEditOperation[]> {
+  ): PromiseLike<monaco.editor.ISingleEditOperation[]> {
     const resource = model.uri;
 
     return this._worker(resource).then((worker) => {
@@ -582,7 +581,7 @@ export class DocumentRangeFormattingEditProvider
 // public provideDocumentColors(
 // model: monaco.editor.IReadOnlyModel,
 // token: CancellationToken
-// ): Thenable<monaco.languages.IColorInformation[]> {
+// ): PromiseLike<monaco.languages.IColorInformation[]> {
 // const resource = model.uri;
 
 // return this._worker(resource)
@@ -602,7 +601,7 @@ export class DocumentRangeFormattingEditProvider
 // model: monaco.editor.IReadOnlyModel,
 // info: monaco.languages.IColorInformation,
 // token: CancellationToken
-// ): Thenable<monaco.languages.IColorPresentation[]> {
+// ): PromiseLike<monaco.languages.IColorPresentation[]> {
 // const resource = model.uri;
 
 // return this._worker(resource)

--- a/src/languageFeatures.ts
+++ b/src/languageFeatures.ts
@@ -19,7 +19,7 @@ import {
   Position,
   Range,
   Uri,
-} from 'monaco-editor';
+} from 'monaco-editor/esm/vs/editor/editor.api';
 import { CustomFormatterOptions } from 'yaml-language-server';
 
 export type WorkerAccessor = (...more: Uri[]) => PromiseLike<YAMLWorker>;

--- a/src/monaco.contribution.ts
+++ b/src/monaco.contribution.ts
@@ -4,7 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import { languages, Emitter, IEvent } from 'monaco-editor';
+import {
+  languages,
+  Emitter,
+  IEvent,
+} from 'monaco-editor/esm/vs/editor/editor.api';
 import { setupMode } from './yamlMode';
 
 declare var require: <T>(

--- a/src/monaco.contribution.ts
+++ b/src/monaco.contribution.ts
@@ -4,10 +4,8 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
+import { languages, Emitter, IEvent } from 'monaco-editor';
 import { setupMode } from './yamlMode';
-
-import Emitter = monaco.Emitter;
-import IEvent = monaco.IEvent;
 
 declare var require: <T>(
   moduleId: [string],
@@ -17,22 +15,20 @@ declare var require: <T>(
 // --- YAML configuration and defaults ---------
 
 export class LanguageServiceDefaultsImpl
-  implements monaco.languages.yaml.LanguageServiceDefaults {
-  private _onDidChange = new Emitter<
-    monaco.languages.yaml.LanguageServiceDefaults
-  >();
-  private _diagnosticsOptions: monaco.languages.yaml.DiagnosticsOptions;
+  implements languages.yaml.LanguageServiceDefaults {
+  private _onDidChange = new Emitter<languages.yaml.LanguageServiceDefaults>();
+  private _diagnosticsOptions: languages.yaml.DiagnosticsOptions;
   private _languageId: string;
 
   constructor(
     languageId: string,
-    diagnosticsOptions: monaco.languages.yaml.DiagnosticsOptions
+    diagnosticsOptions: languages.yaml.DiagnosticsOptions
   ) {
     this._languageId = languageId;
     this.setDiagnosticsOptions(diagnosticsOptions);
   }
 
-  get onDidChange(): IEvent<monaco.languages.yaml.LanguageServiceDefaults> {
+  get onDidChange(): IEvent<languages.yaml.LanguageServiceDefaults> {
     return this._onDidChange.event;
   }
 
@@ -40,19 +36,19 @@ export class LanguageServiceDefaultsImpl
     return this._languageId;
   }
 
-  get diagnosticsOptions(): monaco.languages.yaml.DiagnosticsOptions {
+  get diagnosticsOptions(): languages.yaml.DiagnosticsOptions {
     return this._diagnosticsOptions;
   }
 
   public setDiagnosticsOptions(
-    options: monaco.languages.yaml.DiagnosticsOptions
+    options: languages.yaml.DiagnosticsOptions
   ): void {
     this._diagnosticsOptions = options || Object.create(null);
     this._onDidChange.fire(this);
   }
 }
 
-const diagnosticDefault: monaco.languages.yaml.DiagnosticsOptions = {
+const diagnosticDefault: languages.yaml.DiagnosticsOptions = {
   validate: true,
   schemas: [],
   enableSchemaRequest: false,
@@ -61,22 +57,22 @@ const diagnosticDefault: monaco.languages.yaml.DiagnosticsOptions = {
 const yamlDefaults = new LanguageServiceDefaultsImpl('yaml', diagnosticDefault);
 
 // Export API
-function createAPI(): typeof monaco.languages.yaml {
+function createAPI(): typeof languages.yaml {
   return {
     yamlDefaults,
   };
 }
-monaco.languages.yaml = createAPI();
+languages.yaml = createAPI();
 
 // --- Registration to monaco editor ---
 
-monaco.languages.register({
+languages.register({
   id: 'yaml',
   extensions: ['.yaml', '.yml'],
   aliases: ['YAML', 'yaml', 'YML', 'yml'],
   mimetypes: ['application/x-yaml'],
 });
 
-monaco.languages.onLanguage('yaml', () => {
+languages.onLanguage('yaml', () => {
   setupMode(yamlDefaults);
 });

--- a/src/monaco.d.ts
+++ b/src/monaco.d.ts
@@ -3,52 +3,56 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-declare namespace monaco.languages.yaml {
-  export interface DiagnosticsOptions {
-    /**
-     * If set, the validator will be enabled and perform syntax validation as well as schema based validation.
-     */
-    readonly validate?: boolean;
+import { IEvent } from 'monaco-editor';
 
-    /**
-     * A list of known schemas and/or associations of schemas to file names.
-     */
-    readonly schemas?: Array<{
+declare module 'monaco-editor' {
+  namespace languages.yaml {
+    export interface DiagnosticsOptions {
       /**
-       * The URI of the schema, which is also the identifier of the schema.
+       * If set, the validator will be enabled and perform syntax validation as well as schema based validation.
        */
-      readonly uri: string;
-      /**
-       * A list of file names that are associated to the schema. The '*' wildcard can be used. For example '*.schema.json', 'package.json'
-       */
-      readonly fileMatch?: string[];
-      /**
-       * The schema for the given URI.
-       */
-      readonly schema?: any;
-    }>;
+      readonly validate?: boolean;
 
-    /**
-     *  If set, the schema service would load schema content on-demand with 'fetch' if available
-     */
-    readonly enableSchemaRequest?: boolean;
-    /**
-     * If specified, this prefix will be added to all on demand schema requests
-     */
-    readonly prefix?: string;
-    /**
-     * Whether or not kubernetes yaml is supported
-     */
-    readonly isKubernetes?: boolean;
+      /**
+       * A list of known schemas and/or associations of schemas to file names.
+       */
+      readonly schemas?: Array<{
+        /**
+         * The URI of the schema, which is also the identifier of the schema.
+         */
+        readonly uri: string;
+        /**
+         * A list of file names that are associated to the schema. The '*' wildcard can be used. For example '*.schema.json', 'package.json'
+         */
+        readonly fileMatch?: string[];
+        /**
+         * The schema for the given URI.
+         */
+        readonly schema?: any;
+      }>;
 
-    readonly format?: boolean;
+      /**
+       *  If set, the schema service would load schema content on-demand with 'fetch' if available
+       */
+      readonly enableSchemaRequest?: boolean;
+      /**
+       * If specified, this prefix will be added to all on demand schema requests
+       */
+      readonly prefix?: string;
+      /**
+       * Whether or not kubernetes yaml is supported
+       */
+      readonly isKubernetes?: boolean;
+
+      readonly format?: boolean;
+    }
+
+    export interface LanguageServiceDefaults {
+      readonly onDidChange: IEvent<LanguageServiceDefaults>;
+      readonly diagnosticsOptions: DiagnosticsOptions;
+      setDiagnosticsOptions(options: DiagnosticsOptions): void;
+    }
+
+    export const yamlDefaults: LanguageServiceDefaults;
   }
-
-  export interface LanguageServiceDefaults {
-    readonly onDidChange: IEvent<LanguageServiceDefaults>;
-    readonly diagnosticsOptions: DiagnosticsOptions;
-    setDiagnosticsOptions(options: DiagnosticsOptions): void;
-  }
-
-  export const yamlDefaults: LanguageServiceDefaults;
 }

--- a/src/monaco.d.ts
+++ b/src/monaco.d.ts
@@ -3,9 +3,9 @@
  *  Licensed under the MIT License. See License.txt in the project root for license information.
  *--------------------------------------------------------------------------------------------*/
 
-import { IEvent } from 'monaco-editor';
+import { IEvent } from 'monaco-editor/esm/vs/editor/editor.api';
 
-declare module 'monaco-editor' {
+declare module 'monaco-editor/esm/vs/editor/editor.api' {
   namespace languages.yaml {
     export interface DiagnosticsOptions {
       /**

--- a/src/typings/refs.d.ts
+++ b/src/typings/refs.d.ts
@@ -1,5 +1,0 @@
-/*---------------------------------------------------------------------------------------------
- *  Copyright (c) Microsoft Corporation. All rights reserved.
- *  Licensed under the MIT License. See License.txt in the project root for license information.
- *--------------------------------------------------------------------------------------------*/
-/// <reference path='../../node_modules/monaco-editor-core/monaco.d.ts'/>

--- a/src/workerManager.ts
+++ b/src/workerManager.ts
@@ -4,7 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import { editor, Uri, IDisposable } from 'monaco-editor';
+import {
+  editor,
+  Uri,
+  IDisposable,
+} from 'monaco-editor/esm/vs/editor/editor.api';
 import { LanguageServiceDefaultsImpl } from './monaco.contribution';
 import { YAMLWorker } from './yamlWorker';
 

--- a/src/workerManager.ts
+++ b/src/workerManager.ts
@@ -4,11 +4,9 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
+import { editor, Uri, IDisposable } from 'monaco-editor';
 import { LanguageServiceDefaultsImpl } from './monaco.contribution';
 import { YAMLWorker } from './yamlWorker';
-
-import IDisposable = monaco.IDisposable;
-import Uri = monaco.Uri;
 
 const STOP_WHEN_IDLE_FOR = 2 * 60 * 1000; // 2min
 
@@ -18,7 +16,7 @@ export class WorkerManager {
   private _lastUsedTime: number;
   private _configChangeListener: IDisposable;
 
-  private _worker: monaco.editor.MonacoWebWorker<YAMLWorker>;
+  private _worker: editor.MonacoWebWorker<YAMLWorker>;
   private _client: Promise<YAMLWorker>;
 
   constructor(defaults: LanguageServiceDefaultsImpl) {
@@ -71,7 +69,7 @@ export class WorkerManager {
     this._lastUsedTime = Date.now();
 
     if (!this._client) {
-      this._worker = monaco.editor.createWebWorker<YAMLWorker>({
+      this._worker = editor.createWebWorker<YAMLWorker>({
         // module that exports the create() method and returns a `YAMLWorker` instance
         moduleId: 'vs/language/yaml/yamlWorker',
 

--- a/src/yamlMode.ts
+++ b/src/yamlMode.ts
@@ -4,7 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import { languages, Uri, IDisposable } from 'monaco-editor';
+import {
+  languages,
+  Uri,
+  IDisposable,
+} from 'monaco-editor/esm/vs/editor/editor.api';
 import * as languageFeatures from './languageFeatures';
 import { LanguageServiceDefaultsImpl } from './monaco.contribution';
 import { WorkerManager } from './workerManager';

--- a/src/yamlMode.ts
+++ b/src/yamlMode.ts
@@ -4,13 +4,11 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
+import { languages, Uri, IDisposable } from 'monaco-editor';
 import * as languageFeatures from './languageFeatures';
 import { LanguageServiceDefaultsImpl } from './monaco.contribution';
 import { WorkerManager } from './workerManager';
 import { YAMLWorker } from './yamlWorker';
-
-import Uri = monaco.Uri;
-import IDisposable = monaco.IDisposable;
 
 export function setupMode(defaults: LanguageServiceDefaultsImpl): void {
   const disposables: IDisposable[] = [];
@@ -27,31 +25,31 @@ export function setupMode(defaults: LanguageServiceDefaultsImpl): void {
   const languageId = defaults.languageId;
 
   disposables.push(
-    monaco.languages.registerCompletionItemProvider(
+    languages.registerCompletionItemProvider(
       languageId,
       new languageFeatures.CompletionAdapter(worker)
     )
   );
   disposables.push(
-    monaco.languages.registerHoverProvider(
+    languages.registerHoverProvider(
       languageId,
       new languageFeatures.HoverAdapter(worker)
     )
   );
   disposables.push(
-    monaco.languages.registerDocumentSymbolProvider(
+    languages.registerDocumentSymbolProvider(
       languageId,
       new languageFeatures.DocumentSymbolAdapter(worker)
     )
   );
   disposables.push(
-    monaco.languages.registerDocumentFormattingEditProvider(
+    languages.registerDocumentFormattingEditProvider(
       languageId,
       new languageFeatures.DocumentFormattingEditProvider(worker)
     )
   );
   disposables.push(
-    monaco.languages.registerDocumentRangeFormattingEditProvider(
+    languages.registerDocumentRangeFormattingEditProvider(
       languageId,
       new languageFeatures.DocumentRangeFormattingEditProvider(worker)
     )
@@ -60,14 +58,14 @@ export function setupMode(defaults: LanguageServiceDefaultsImpl): void {
     new languageFeatures.DiagnosticsAdapter(languageId, worker, defaults)
   );
   disposables.push(
-    monaco.languages.setLanguageConfiguration(languageId, richEditConfiguration)
+    languages.setLanguageConfiguration(languageId, richEditConfiguration)
   );
 
   // Color adapter should be necessary most of the time:
-  // disposables.push(monaco.languages.registerColorProvider(languageId, new languageFeatures.DocumentColorAdapter(worker)));
+  // disposables.push(languages.registerColorProvider(languageId, new languageFeatures.DocumentColorAdapter(worker)));
 }
 
-const richEditConfiguration: monaco.languages.LanguageConfiguration = {
+const richEditConfiguration: languages.LanguageConfiguration = {
   comments: {
     lineComment: '#',
   },
@@ -94,7 +92,7 @@ const richEditConfiguration: monaco.languages.LanguageConfiguration = {
   onEnterRules: [
     {
       beforeText: /:\s*$/,
-      action: { indentAction: monaco.languages.IndentAction.Indent },
+      action: { indentAction: languages.IndentAction.Indent },
     },
   ],
 };

--- a/src/yamlWorker.ts
+++ b/src/yamlWorker.ts
@@ -6,7 +6,7 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import { worker } from 'monaco-editor';
+import { worker } from 'monaco-editor/esm/vs/editor/editor.api';
 import * as ls from 'vscode-languageserver-types';
 import * as yamlService from 'yaml-language-server';
 

--- a/src/yamlWorker.ts
+++ b/src/yamlWorker.ts
@@ -6,7 +6,6 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import Thenable = monaco.Thenable;
 import IWorkerContext = monaco.worker.IWorkerContext;
 
 import * as ls from 'vscode-languageserver-types';
@@ -46,7 +45,7 @@ export class YAMLWorker {
     });
   }
 
-  public doValidation(uri: string): Thenable<ls.Diagnostic[]> {
+  public doValidation(uri: string): PromiseLike<ls.Diagnostic[]> {
     const document = this._getTextDocument(uri);
     if (document) {
       return this._languageService.doValidation(document, this._isKubernetes);
@@ -57,7 +56,7 @@ export class YAMLWorker {
   public doComplete(
     uri: string,
     position: ls.Position
-  ): Thenable<ls.CompletionList> {
+  ): PromiseLike<ls.CompletionList> {
     const document = this._getTextDocument(uri);
     return this._languageService.doComplete(
       document,
@@ -66,11 +65,11 @@ export class YAMLWorker {
     );
   }
 
-  public doResolve(item: ls.CompletionItem): Thenable<ls.CompletionItem> {
+  public doResolve(item: ls.CompletionItem): PromiseLike<ls.CompletionItem> {
     return this._languageService.doResolve(item);
   }
 
-  public doHover(uri: string, position: ls.Position): Thenable<ls.Hover> {
+  public doHover(uri: string, position: ls.Position): PromiseLike<ls.Hover> {
     const document = this._getTextDocument(uri);
     return this._languageService.doHover(document, position);
   }
@@ -79,17 +78,17 @@ export class YAMLWorker {
     uri: string,
     range: ls.Range,
     options: yamlService.CustomFormatterOptions
-  ): Thenable<ls.TextEdit[]> {
+  ): PromiseLike<ls.TextEdit[]> {
     const document = this._getTextDocument(uri);
     const textEdits = this._languageService.doFormat(document, options);
     return Promise.resolve(textEdits);
   }
 
-  public resetSchema(uri: string): Thenable<boolean> {
+  public resetSchema(uri: string): PromiseLike<boolean> {
     return Promise.resolve(this._languageService.resetSchema(uri));
   }
 
-  public findDocumentSymbols(uri: string): Thenable<ls.DocumentSymbol[]> {
+  public findDocumentSymbols(uri: string): PromiseLike<ls.DocumentSymbol[]> {
     const document = this._getTextDocument(uri);
     const symbols = this._languageService.findDocumentSymbols2(document);
     return Promise.resolve(symbols);

--- a/src/yamlWorker.ts
+++ b/src/yamlWorker.ts
@@ -6,8 +6,7 @@
  *--------------------------------------------------------------------------------------------*/
 'use strict';
 
-import IWorkerContext = monaco.worker.IWorkerContext;
-
+import { worker } from 'monaco-editor';
 import * as ls from 'vscode-languageserver-types';
 import * as yamlService from 'yaml-language-server';
 
@@ -19,13 +18,13 @@ if (typeof fetch !== 'undefined') {
 }
 
 export class YAMLWorker {
-  private _ctx: IWorkerContext;
+  private _ctx: worker.IWorkerContext;
   private _languageService: yamlService.LanguageService;
   private _languageSettings: yamlService.LanguageSettings;
   private _languageId: string;
   private _isKubernetes: boolean;
 
-  constructor(ctx: IWorkerContext, createData: ICreateData) {
+  constructor(ctx: worker.IWorkerContext, createData: ICreateData) {
     const prefix = createData.prefix || '';
     const service = (url: string) =>
       defaultSchemaRequestService(`${prefix}${url}`);
@@ -119,7 +118,7 @@ export interface ICreateData {
 }
 
 export function create(
-  ctx: IWorkerContext,
+  ctx: worker.IWorkerContext,
   createData: ICreateData
 ): YAMLWorker {
   return new YAMLWorker(ctx, createData);

--- a/yarn.lock
+++ b/yarn.lock
@@ -556,15 +556,10 @@ minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-monaco-editor-core@^0.21.2:
-  version "0.21.2"
-  resolved "https://registry.yarnpkg.com/monaco-editor-core/-/monaco-editor-core-0.21.2.tgz#06e94d625bf7edc452e4d32c41a96229875001ec"
-  integrity sha512-uYk9x50dkFsoAHmzYytS29ohDlb2JZsGowK5icwra8FYwdOy77uAq2bDCMYo6NZ4T/aKRKOnnO5S3ifaJwqaBw==
-
-monaco-editor@^0.21.2:
-  version "0.21.2"
-  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.21.2.tgz#37054e63e480d51a2dd17d609dcfb192304d5605"
-  integrity sha512-jS51RLuzMaoJpYbu7F6TPuWpnWTLD4kjRW0+AZzcryvbxrTwhNy1KC9yboyKpgMTahpUbDUsuQULoo0GV1EPqg==
+monaco-editor@^0.21.3:
+  version "0.21.3"
+  resolved "https://registry.yarnpkg.com/monaco-editor/-/monaco-editor-0.21.3.tgz#3381b66614b64d1c5e3b77dd5564ad496d1b4e5d"
+  integrity sha512-9N7wATLpi+googstvtm6IKg97vPQ77FDYEpkow5tLriM/VJ0DaTRyUP4UVzcoH7KlPDX+e/rE7/imcOUeGkT6g==
 
 monaco-languages@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
This is a preparation for `monaco-editor@^0.22.0`. In this version the global `monaco` object was removed for ESM users.
    
A choice was made to use `monaco-editor` imports, because this probably has best compatibility for most users. If users want to use `monaco-editor-core`, they will have to create an alias in their own build process.

Closes #24
Closes #44