### PR TITLE
Expose setDiagnosticsOptions in monaco-yaml

### DIFF
--- a/.eslintrc.yaml
+++ b/.eslintrc.yaml
@@ -9,6 +9,7 @@ rules:
 
   '@typescript-eslint/naming-convention': off
   '@typescript-eslint/no-parameter-properties': off
+  '@typescript-eslint/no-shadow': off
   '@typescript-eslint/prefer-optional-chain': off
 
   import/no-extraneous-dependencies: off

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ files:
 - Automatically load remote schema files (by enabling DiagnosticsOptions.enableSchemaRequest)
 
 Schemas can also be provided by configuration. See
-[here](https://github.com/Microsoft/monaco-json/blob/master/src/monaco.d.ts) for the API that the
-JSON plugin offers to configure the JSON language support.
+[here](https://github.com/Microsoft/monaco-json/blob/master/index.d.ts) for the API that the JSON
+plugin offers to configure the JSON language support.
 
 ## Installation
 
@@ -26,13 +26,13 @@ npm install monaco-yaml
 Import `monaco-yaml` and configure it before an editor instance is created.
 
 ```ts
-import { editor, languages, Uri } from 'monaco-editor';
-import 'monaco-yaml';
+import { editor, Uri } from 'monaco-editor';
+import { setDiagnosticsOptions } from 'monaco-yaml';
 
 // The uri is used for the schema file match.
 const modelUri = Uri.parse('a://b/foo.yaml');
 
-languages.yaml.yamlDefaults.setDiagnosticsOptions({
+setDiagnosticsOptions({
   enableSchemaRequest: true,
   hover: true,
   completion: true,

--- a/examples/webpack-worker-loader/src/index.js
+++ b/examples/webpack-worker-loader/src/index.js
@@ -4,8 +4,8 @@ import './index.css';
 // features you want to use, import them each individually. See this example: (https://github.com/microsoft/monaco-editor-samples/blob/master/browser-esm-webpack-small/index.js#L1-L91)
 import 'monaco-editor';
 
-import { editor, languages } from 'monaco-editor/esm/vs/editor/editor.api';
-import 'monaco-yaml';
+import { editor } from 'monaco-editor/esm/vs/editor/editor.api';
+import { setDiagnosticsOptions } from 'monaco-yaml';
 // NOTE: using loader syntax becuase Yaml worker imports editor.worker directly and that
 // import shouldn't go through loader syntax.
 import EditorWorker from 'worker-loader!monaco-editor/esm/vs/editor/editor.worker';
@@ -20,7 +20,7 @@ window.MonacoEnvironment = {
   },
 };
 
-languages.yaml.yamlDefaults.setDiagnosticsOptions({
+setDiagnosticsOptions({
   validate: true,
   enableSchemaRequest: true,
   hover: true,

--- a/examples/webpack/src/index.js
+++ b/examples/webpack/src/index.js
@@ -1,7 +1,7 @@
 import './index.css';
 
-import { editor, languages } from 'monaco-editor/esm/vs/editor/editor.api';
-import 'monaco-yaml/lib/esm/monaco.contribution';
+import { editor } from 'monaco-editor/esm/vs/editor/editor.api';
+import { setDiagnosticsOptions } from 'monaco-yaml';
 
 // NOTE: This will give you all editor featues. If you would prefer to limit to only the editor
 // features you want to use, import them each individually. See this example: (https://github.com/microsoft/monaco-editor-samples/blob/master/browser-esm-webpack-small/index.js#L1-L91)
@@ -16,7 +16,7 @@ window.MonacoEnvironment = {
   },
 };
 
-languages.yaml.yamlDefaults.setDiagnosticsOptions({
+setDiagnosticsOptions({
   validate: true,
   enableSchemaRequest: true,
   hover: true,

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,5 @@
 import { JSONSchema4, JSONSchema6, JSONSchema7 } from 'json-schema';
-import { IEvent } from 'monaco-editor/esm/vs/editor/editor.api';
+import { IEvent, languages } from 'monaco-editor/esm/vs/editor/editor.api';
 
 declare module 'monaco-editor/esm/vs/editor/editor.api' {
   namespace languages.yaml {
@@ -64,3 +64,10 @@ declare module 'monaco-editor/esm/vs/editor/editor.api' {
     export const yamlDefaults: LanguageServiceDefaults;
   }
 }
+
+/**
+ * Configure `monaco-yaml` diagnostics options.
+ *
+ * @param options - The options to set.
+ */
+export function setDiagnosticsOptions(options?: languages.yaml.DiagnosticsOptions): void;

--- a/package.json
+++ b/package.json
@@ -5,16 +5,17 @@
   "scripts": {
     "watch": "tsc -p ./src --watch",
     "compile": "rimraf ./out && tsc",
-    "bundle": "rimraf ./lib && node ./scripts/bundle-esm && mcopy ./src/monaco.d.ts ./lib/monaco.d.ts",
+    "bundle": "rimraf ./lib && node ./scripts/bundle-esm",
     "prepack": "npm run compile && npm run bundle",
     "prepare": "husky install",
     "lint": "eslint . && prettier --check ."
   },
   "main": "./lib/esm/monaco.contribution.js",
   "module": "./lib/esm/monaco.contribution.js",
-  "typings": "./lib/monaco.d.ts",
+  "typings": "./index.d.ts",
   "files": [
-    "lib"
+    "lib",
+    "index.d.ts"
   ],
   "workspaces": [
     "examples/*"

--- a/src/monaco.contribution.ts
+++ b/src/monaco.contribution.ts
@@ -60,3 +60,12 @@ languages.register({
 languages.onLanguage('yaml', () => {
   setupMode(yamlDefaults);
 });
+
+/**
+ * Configure `monaco-yaml` diagnostics options.
+ *
+ * @param options - The options to set.
+ */
+export function setDiagnosticsOptions(options: languages.yaml.DiagnosticsOptions = {}): void {
+  languages.yaml.yamlDefaults.setDiagnosticsOptions(options);
+}


### PR DESCRIPTION
This removes the need to explain certain statements and imports need to
happen in a specific order. Users can now just use:

```ts
import { setDiagnosticsOptions } from 'monaco-yaml';

setDiagnosticsOptions({});
```